### PR TITLE
Better Linux support & ZipFile

### DIFF
--- a/Assets/_ModdingToolScripts/asm_Packer/ModPackerModule/ModPacker/PackerInfo/Archive.cs
+++ b/Assets/_ModdingToolScripts/asm_Packer/ModPackerModule/ModPacker/PackerInfo/Archive.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 // TODO: Add Detailed Log file to see what the fuck went wrong
 // TODO: make log file tail-able. latest.log -> [date]_mod.log copy
@@ -13,7 +14,7 @@ namespace ModPackerModule
         {
             public void SetupModFolder()
             {
-                var zipPath = Path.Combine(TempFolder, _fileName).Replace("/", "\\");
+                var zipPath = Path.Combine(TempFolder, _fileName).Replace("\\", "/");
                 if (Directory.Exists(zipPath)) Directory.Delete(zipPath, true);
                 Directory.CreateDirectory(zipPath);
 
@@ -53,23 +54,12 @@ namespace ModPackerModule
 
             public void DeployZipMod(string targetPath)
             {
-                var srcPath = Path.Combine(TempFolder, Path.Combine(_fileName, "*")).Replace("\\", "/");
+                var srcPath = Path.Combine(TempFolder, Path.Combine(_fileName)).Replace("\\", "/");
                 var extPath = Path.Combine(targetPath, _fileName + ".zipmod").Replace("\\", "/");
-                var zipExec = Path.Combine(Directory.GetCurrentDirectory(), "_External\\7za.exe").Replace("\\", "/");
-
+   
                 if (File.Exists(extPath)) File.Delete(extPath);
                 
-                var p = new Process
-                {
-                    StartInfo =
-                    {
-                        UseShellExecute = false, FileName = zipExec, Arguments = $"a -tzip -aoa -w{Environment.GetEnvironmentVariable("TEMP")} \"{extPath}\" \"{srcPath}\""
-                    }
-                };
-                p.Start();
-                p.WaitForExit();
-                if (p.ExitCode != 0)
-                    throw new Exception("Failed to make zip file. (" + p.ExitCode + ")");
+                ZipFile.CreateFromDirectory(srcPath, extPath);
             }
         }
     }

--- a/Assets/csc.rsp
+++ b/Assets/csc.rsp
@@ -1,0 +1,1 @@
+-r:System.IO.Compression.FileSystem.dll

--- a/Assets/mcs.rsp
+++ b/Assets/mcs.rsp
@@ -1,0 +1,1 @@
+-r:System.IO.Compression.FileSystem.dll


### PR DESCRIPTION
* Use ZipFile instead of the included 7za.exe
* Fix _Temporary path being created with back slashes to forward slashes

Both of these changes make this tool work good on Linux (only tried making HS2 maps thou), using ZipFile allows you to get rid of the 7za dependency.